### PR TITLE
Implement predictive back handling and edge-to-edge

### DIFF
--- a/.phrasey/hooks.js
+++ b/.phrasey/hooks.js
@@ -35,10 +35,10 @@ package io.github.zyrouge.symphony.services.i18n
 
 @Suppress("ClassName")
 open class _Translations {
-    val localeCodes = listOf(
+    val localeCodes: List<String> = listOf(
 ${translations.map((x) => `        "${x.locale.code}",`).join("\n")}
     )
-    val localeNames = mapOf(
+    val localeNames: Map<String, String> = mapOf(
 ${translations
     .map((x) => `        "${x.locale.code}" to "${x.locale.name}",`)
     .join("\n")}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,7 +66,6 @@ android {
 }
 
 dependencies {
-    implementation(libs.accompanist.navigation.animation)
     implementation(libs.activity.compose)
     implementation(libs.coil)
     implementation(libs.compose.material.icons.extended)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,16 +14,18 @@
         android:name="android.permission.BLUETOOTH"
         android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
+        android:enableOnBackInvokedCallback="true"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.Symphony"
-        tools:targetApi="31">
+        tools:targetApi="tiramisu">
         <activity
             android:name=".MainActivity"
             android:exported="true"
@@ -43,6 +45,7 @@
 
         <service
             android:name=".services.radio.RadioNotificationService"
+            android:foregroundServiceType="mediaPlayback"
             android:stopWithTask="true" />
     </application>
 </manifest>

--- a/app/src/main/java/io/github/zyrouge/symphony/MainActivity.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.viewModels
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.core.view.WindowCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.github.zyrouge.symphony.ui.view.BaseView
@@ -39,6 +40,9 @@ class MainActivity : ComponentActivity() {
         gSymphony = symphony
         symphony.ready()
         attachHandlers()
+
+        // Allow app to draw behind system bar decorations (e.g.: navbar)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
 
         // NOTE: disables action bar on orientation changes (esp. in miui)
         actionBar?.hide()

--- a/app/src/main/java/io/github/zyrouge/symphony/MainActivity.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/MainActivity.kt
@@ -2,7 +2,6 @@ package io.github.zyrouge.symphony
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
-import androidx.activity.addCallback
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.runtime.LaunchedEffect
@@ -65,9 +64,10 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun attachHandlers() {
-        onBackPressedDispatcher.addCallback {
-            moveTaskToBack(true)
-        }
+        // onBackPressedDispatcher.addCallback {
+        //     moveTaskToBack(true)
+        // }
+        // Interferes with the predictive back handling, and AFAIK the app works fine without this.
         gSymphony?.closeApp = {
             finish()
         }

--- a/app/src/main/java/io/github/zyrouge/symphony/services/radio/RadioNotificationManager.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/radio/RadioNotificationManager.kt
@@ -5,6 +5,8 @@ import android.app.Notification
 import android.app.Service
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo
+import android.os.Build
 import android.os.IBinder
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationChannelCompat
@@ -89,7 +91,15 @@ class RadioNotificationManager(val symphony: Symphony) {
         state = State.READY
         lastNotification?.let { notification ->
             lastNotification = null
-            service!!.startForeground(RadioNotification.NOTIFICATION_ID, notification)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q){
+                // If running Android 10 or newer, specify that the foreground service is for
+                // media playback. This allows the app to function on Android 14, namely.
+                service!!.startForeground(RadioNotification.NOTIFICATION_ID, notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
+            } else{
+                // We're running a version under Android 10; we cannot specify such attribute.
+                service!!.startForeground(RadioNotification.NOTIFICATION_ID, notification)
+            }
         }
     }
 

--- a/app/src/main/java/io/github/zyrouge/symphony/services/radio/RadioSession.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/radio/RadioSession.kt
@@ -43,15 +43,34 @@ class RadioSession(val symphony: Symphony) {
     }
 
     fun start() {
-        symphony.applicationContext.registerReceiver(
-            receiver,
-            IntentFilter().apply {
-                addAction(ACTION_PLAY_PAUSE)
-                addAction(ACTION_PREVIOUS)
-                addAction(ACTION_NEXT)
-                addAction(ACTION_STOP)
-            }
-        )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            // As per Tiramisu requirements, we need to add Context attributes.
+            symphony.applicationContext.registerReceiver(
+                receiver,
+                IntentFilter().apply {
+                    addAction(ACTION_PLAY_PAUSE)
+                    addAction(ACTION_PREVIOUS)
+                    addAction(ACTION_NEXT)
+                    addAction(ACTION_STOP)
+                },
+                Context.RECEIVER_EXPORTED
+                // https://developer.android.com/reference/android/content/Context#RECEIVER_EXPORTED
+                // really, RECEIVER_EXPORTED and RECEIVER_NOT_EXPORTED makes no difference.
+                // the notification appears perfectly, Pano Scrobbler sees it,
+                // Wear OS can send signals to play/pause the app, other media apps can pause it,
+                // no clue what the difference here is... but here we are.
+            )
+        } else{
+            symphony.applicationContext.registerReceiver(
+                receiver,
+                IntentFilter().apply {
+                    addAction(ACTION_PLAY_PAUSE)
+                    addAction(ACTION_PREVIOUS)
+                    addAction(ACTION_NEXT)
+                    addAction(ACTION_STOP)
+                }
+            )
+        }
         mediaSession.setCallback(
             object : MediaSessionCompat.Callback() {
                 override fun onPlay() {

--- a/app/src/main/java/io/github/zyrouge/symphony/ui/components/NowPlayingBottomBar.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/components/NowPlayingBottomBar.kt
@@ -37,7 +37,7 @@ import kotlin.math.absoluteValue
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalAnimationApi::class)
 @Composable
-fun NowPlayingBottomBar(context: ViewContext) {
+fun NowPlayingBottomBar(context: ViewContext, drawInset: Boolean = true) {
     val queue = context.symphony.radio.observatory.queue
     val queueIndex by context.symphony.radio.observatory.queueIndex.collectAsState()
     val currentPlayingSong by remember {
@@ -202,6 +202,9 @@ fun NowPlayingBottomBar(context: ViewContext) {
                         }
                         Spacer(modifier = Modifier.width(8.dp))
                     }
+                }
+                if(drawInset){
+                    Spacer(modifier = Modifier.navigationBarsPadding())
                 }
             }
         }

--- a/app/src/main/java/io/github/zyrouge/symphony/ui/view/Base.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/view/Base.kt
@@ -1,35 +1,33 @@
 package io.github.zyrouge.symphony.ui.view
 
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import com.google.accompanist.navigation.animation.AnimatedNavHost
-import com.google.accompanist.navigation.animation.composable
-import com.google.accompanist.navigation.animation.rememberAnimatedNavController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.compose.composable
 import io.github.zyrouge.symphony.MainActivity
 import io.github.zyrouge.symphony.Symphony
 import io.github.zyrouge.symphony.ui.helpers.*
 import io.github.zyrouge.symphony.ui.theme.SymphonyTheme
 
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun BaseView(symphony: Symphony, activity: MainActivity) {
     val context = ViewContext(
         symphony = symphony,
         activity = activity,
-        navController = rememberAnimatedNavController(),
+        navController = rememberNavController(),
     )
 
     SymphonyTheme(context) {
         Surface(color = MaterialTheme.colorScheme.background) {
-            AnimatedNavHost(
+            NavHost(
                 navController = context.navController,
                 startDestination = Routes.Home.route
             ) {
                 composable(
                     Routes.Home.route,
-                    popEnterTransition = { FadeTransition.enterTransition() },
+                    enterTransition = { FadeTransition.enterTransition() },
                 ) {
                     HomeView(context)
                 }

--- a/app/src/main/java/io/github/zyrouge/symphony/ui/view/Home.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/view/Home.kt
@@ -227,7 +227,7 @@ fun HomeView(context: ViewContext) {
         },
         bottomBar = {
             Column {
-                NowPlayingBottomBar(context)
+                NowPlayingBottomBar(context, false)
                 NavigationBar {
                     Spacer(modifier = Modifier.width(2.dp))
                     tabs.map { page ->

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -3,5 +3,14 @@
 
     <style name="Theme.Symphony" parent="android:Theme.Material.Light.NoActionBar">
         <item name="android:windowLayoutInDisplayCutoutMode">default</item>
+
+        <!-- Edge-to-edge display -->
+        <item name="android:navigationBarColor">
+            @android:color/transparent
+        </item>
+        <item name="android:statusBarColor">
+            @android:color/transparent
+        </item>
+
     </style>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-accompanist = '0.27.0'
 activity-compose = "1.8.0-alpha06"
 coil = "2.4.0"
 compose = "1.4.3"
@@ -22,7 +21,6 @@ min-sdk = "28"
 target-sdk = "34"
 
 [libraries]
-accompanist-navigation-animation = { group = "com.google.accompanist", name = "accompanist-navigation-animation", version.ref = "accompanist" }
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
 coil = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "compose-material" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 accompanist = '0.27.0'
 activity-compose = "1.8.0-alpha06"
-coil = "2.3.0"
+coil = "2.4.0"
 compose = "1.4.3"
 compose-compiler = "1.4.7"
 compose-material = "1.4.3"
-compose-material3 = "1.1.0"
-compose-navigation = "2.5.3"
+compose-material3 = "1.2.0-alpha03"
+compose-navigation = "2.7.0-beta02"
 core = "1.10.1"
 core-splashscreen = "1.0.1"
 jaudiotagger = "3.0.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 accompanist = '0.27.0'
-activity-compose = "1.7.2"
+activity-compose = "1.8.0-alpha06"
 coil = "2.3.0"
 compose = "1.4.3"
 compose-compiler = "1.4.7"
@@ -14,12 +14,12 @@ lifecycle-runtime = "2.6.1"
 media = "1.6.0"
 okhttp3 = "4.11.0"
 
-android-gradle-plugin = "8.0.2"
+android-gradle-plugin = "8.1.0-rc01"
 kotlin-gradle-plugin = "1.8.21"
 
-compile-sdk = "33"
+compile-sdk = "34"
 min-sdk = "28"
-target-sdk = "33"
+target-sdk = "34"
 
 [libraries]
 accompanist-navigation-animation = { group = "com.google.accompanist", name = "accompanist-navigation-animation", version.ref = "accompanist" }


### PR DESCRIPTION
### Description

This pull request does several things:
- changes the code to target API 34 (Android 14) and changes the radio service to function with new requirements (like foreground services requiring a ServiceInfo element, and receivers requiring context as to what they are)
- updates several dependencies, some may have unintended drawbacks however
- deprecates the custom `onBackPressedDispatcher` callback added in `attachHandlers()` [as seen here](https://github.com/AtlasC0R3/symphony/commit/093bb408343fb0f42fe52ac6fe47de985c52642d#diff-3799660c5c623477ad21667d6ff009aff16d5e4bfb2d31aadc9d58f0e1d14be7L68) (in my testing this has not caused any issues, but since I do not know why this was added in the first place, I cannot tell for sure)
- allows predictive back handling, in Android 13, and more prominently Android 14, to function as much as Compose allows. _(to be honest here, Google haven't yet worked on implementing this feature very fully on Compose, this is only doing the bare minimum... this is also why several dependencies need to be on Alpha or Beta; we are running on bleeding-edge features.)_
- substitutes deprecated Accompanist functions with native Compose replacements
- fully implements edge-to-edge display on the app.
- fixes `.phrasey/hooks.js` to generate `Translations.g.kt` with proper class types, no longer making Kotlin (fail to) infer

I'll be honest and say that this may not be the most stable of changes, as I have only been able to test on a Pixel 6 running the latest Android 14 Beta (UPB4.230623.005), and have not tested on other, older devices. Hopefully, however, they still function as they used to. So please do test yourself and see if these features belong to be merged.

Fixes #193 (edge-to-edge).

### Screenshots of changes in action
#### Predictive back handling as shown in Android 14 (does not work with activity changes AFAIK)
https://github.com/zyrouge/symphony/assets/39468657/cbc2a8bd-cca1-4e21-95a3-8629fdb662f3

#### Edge-to-edge display
Gesture navigation   |  3-button navigation
:----------------------------:|:-------------------------:
![Screenshot_20230714-193154](https://github.com/zyrouge/symphony/assets/39468657/514be0bf-9e7d-463f-b42e-4ed56708ffaa) | ![Screenshot_20230714-193757](https://github.com/zyrouge/symphony/assets/39468657/480bea4b-fbdc-4315-88c2-62529a36ebc5)
![Screenshot_20230714-193426](https://github.com/zyrouge/symphony/assets/39468657/d7c8d413-8e21-4ece-931f-5bf776076d1d) |![Screenshot_20230714-193903](https://github.com/zyrouge/symphony/assets/39468657/3dda4093-f5c8-4549-a50b-f0de4cc580af)
![Screenshot_20230714-193307](https://github.com/zyrouge/symphony/assets/39468657/222d7e62-733f-4176-9514-9e79727d5bed) | ![Screenshot_20230714-194000](https://github.com/zyrouge/symphony/assets/39468657/d1fe553a-f64f-400b-9c18-5fb9975bfc22)
![Screenshot_20230714-193335](https://github.com/zyrouge/symphony/assets/39468657/7d7b29ee-2b68-445c-a1a0-c67a5ffaabce) |![Screenshot_20230714-193850](https://github.com/zyrouge/symphony/assets/39468657/59de7a8e-cdb0-44b5-9ef0-6e8628cdbcf9)



### Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) **(not sure if this applies! from my not-that-thorough testing, it hasn't caused any issues, but still)**

### Checklist

-   [x] I have read the [Contribution Guidelines](https://github.com/zyrouge/symphony/wiki/Contributions-Guidelines#pull-requests).