### PR TITLE
Make genre page title display properly

### DIFF
--- a/app/src/main/java/io/github/zyrouge/symphony/ui/view/Genre.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/view/Genre.kt
@@ -58,7 +58,8 @@ fun GenreView(context: ViewContext, genreId: String) {
                 },
                 title = {
                     TopAppBarMinimalTitle {
-                        Text("${context.symphony.t.Genre} - $genre")
+                        Text(context.symphony.t.Genre
+                                + (genre?.let { " - ${it.name}" } ?: ""))
                     }
                 },
                 actions = {


### PR DESCRIPTION
Fixes #349.

![image](https://github.com/zyrouge/symphony/assets/22648124/1d408026-00b4-4730-a30f-08fbae7278a0)
