### PR TITLE
Fix: Queue clear causes out of bounds exception

### DIFF
--- a/app/src/main/java/io/github/zyrouge/symphony/ui/view/Queue.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/view/Queue.kt
@@ -111,6 +111,7 @@ fun QueueView(context: ViewContext) {
                     IconButton(
                         onClick = {
                             context.symphony.radio.stop()
+                            selectedSongIndices.clear()
                         }
                     ) {
                         Icon(Icons.Filled.ClearAll, null)


### PR DESCRIPTION
Closes #578

This fixes the bug in gui code. However, service functions shouldn't necessarily trust gui code to be correct in the first place.