### PR TITLE
Fix annoying media folder dialog behavior

### DIFF
--- a/app/src/main/java/io/github/zyrouge/symphony/ui/components/settings/MultiSystemFolderTile.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/components/settings/MultiSystemFolderTile.kt
@@ -71,7 +71,6 @@ fun SettingsMultiSystemFolderTile(
         key(values.size) {
             ScaffoldDialog(
                 onDismissRequest = {
-                    onChange(values.toSet())
                     showDialog = false
                 },
                 title = title,

--- a/app/src/main/java/io/github/zyrouge/symphony/ui/view/settings/GrooveSettingsView.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/view/settings/GrooveSettingsView.kt
@@ -140,8 +140,10 @@ fun GrooveSettingsView(context: ViewContext, route: GrooveSettingsViewRoute) {
                             },
                             initialValues = mediaFolders,
                             onChange = { values ->
-                                context.symphony.settings.mediaFolders.setValue(values)
-                                refreshMediaLibrary(context.symphony)
+                                if (values != context.symphony.settings.mediaFolders.value) {
+                                    context.symphony.settings.mediaFolders.setValue(values)
+                                    refreshMediaLibrary(context.symphony)
+                                }
                             }
                         )
                     }


### PR DESCRIPTION
- do not save/apply folder changes on dismiss (i think this is a bug, as pressing cancel does not apply the changes)
- only refresh library on actual changes (annoying, as the scan takes some time)