### PR TITLE
Fix multiline lyrics and set consistent lyrics style

### DIFF
--- a/app/src/main/java/io/github/zyrouge/symphony/ui/components/TimedContentText.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/components/TimedContentText.kt
@@ -132,7 +132,8 @@ fun TimedContentText(
         }
         itemsIndexed(content.pairs) { i, x ->
             val highlight = !content.isSynced || i < activeIndex
-            val active = i == activeIndex
+            val active = i == activeIndex ||
+                    (highlight && content.pairs[activeIndex].first == x.first)
 
             val textStyle by animateTextStyleAsState(
                 targetValue = when {

--- a/app/src/main/java/io/github/zyrouge/symphony/ui/view/Lyrics.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/view/Lyrics.kt
@@ -95,18 +95,9 @@ fun LyricsView(context: ViewContext) {
                         Box(modifier = Modifier.weight(1f)) {
                             LyricsText(
                                 context,
-                                style = TimedContentTextStyle(
-                                    highlighted = MaterialTheme.typography.titleMedium.copy(
-                                        color = LocalContentColor.current,
-                                    ),
-                                    active = MaterialTheme.typography.titleLarge.copy(
-                                        fontWeight = FontWeight.Bold,
-                                        color = MaterialTheme.colorScheme.primary,
-                                    ),
-                                    inactive = MaterialTheme.typography.titleMedium.copy(
-                                        color = LocalContentColor.current.copy(alpha = 0.5f),
-                                    ),
-                                    spacing = 8.dp,
+                                style = TimedContentTextStyle.defaultStyle(
+                                    textStyle = MaterialTheme.typography.titleLarge.copy(color = LocalContentColor.current),
+                                    contentColor = LocalContentColor.current,
                                 ),
                                 padding = PaddingValues(
                                     horizontal = defaultHorizontalPadding,

--- a/app/src/main/java/io/github/zyrouge/symphony/ui/view/nowPlaying/BodyCover.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/view/nowPlaying/BodyCover.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.min
 import coil.compose.AsyncImage
@@ -95,7 +96,7 @@ private fun NowPlayingBodyCoverLyrics(context: ViewContext, orientation: ScreenO
                 vertical = 8.dp,
             ),
             style = TimedContentTextStyle.defaultStyle(
-                textStyle = LocalTextStyle.current,
+                textStyle = MaterialTheme.typography.titleLarge.copy(color = LocalContentColor.current),
                 contentColor = LocalContentColor.current,
             ),
         )


### PR DESCRIPTION
- Multi line active state: oppose to #789, this approach did not fix any current parse issue, but only implement a soft check under component
- Consistent style: animation should not shift element size, also the style is quite different in cover and lyric view (unbold text making un-significant shift anyway)

| ![Screenshot_2025-05-17-14-50-12-624_io github zyrouge symphony debug](https://github.com/user-attachments/assets/06b552fc-5ade-460c-a447-1885cfa5683f) | ![Screenshot_2025-05-17-14-43-55-048_io github zyrouge symphony debug](https://github.com/user-attachments/assets/1b2864c5-096d-4d01-a57e-f9f4cb0aecd0) |
| ------------- | ------------- |

Fixing timing is pretty temporary, but would compatible with #789 anyway, cheers.