### PR TITLE
Add Shuffle Persistence

### DIFF
--- a/app/src/main/java/io/github/zyrouge/symphony/services/Settings.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/Settings.kt
@@ -329,6 +329,7 @@ class Settings(private val symphony: Symphony) {
     val gaplessPlayback = BooleanEntry("gapless_playback", true)
     val caseSensitiveSorting = BooleanEntry("case_sensitive_sorting", false)
     val lyricsKeepScreenAwake = BooleanEntry("lyrics_keep_screen_awake", true)
+    val lastUsedShuffleMode = BooleanEntry("last_used_shuffle_mode", false)
 
     private fun getSharedPreferences() = symphony.applicationContext
         .getSharedPreferences("settings", Context.MODE_PRIVATE)

--- a/app/src/main/java/io/github/zyrouge/symphony/services/radio/RadioQueue.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/radio/RadioQueue.kt
@@ -123,6 +123,7 @@ class RadioQueue(private val symphony: Symphony) {
 
     fun setShuffleMode(to: Boolean) {
         currentShuffleMode = to
+        symphony.settings.lastUsedShuffleMode.setValue(to)
         if (currentQueue.isNotEmpty()) {
             val currentSongId = getSongIdAt(currentSongIndex) ?: getSongIdAt(0)!!
             currentSongIndex = if (currentShuffleMode) {

--- a/app/src/main/java/io/github/zyrouge/symphony/services/radio/RadioShorty.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/radio/RadioShorty.kt
@@ -69,7 +69,7 @@ class RadioShorty(private val symphony: Symphony) {
                 copy(index = if (shuffle) Random.nextInt(songIds.size) else options.index)
             }
         )
-        symphony.radio.queue.setShuffleMode(shuffle)
+        symphony.radio.queue.setShuffleMode(shuffle || symphony.settings.lastUsedShuffleMode.value)
     }
 
     fun playQueue(


### PR DESCRIPTION
Save the Shuffle Mode over Song switches & restarts

~~It removes the line `if (shuffle) Random.nextInt(songIds.size)` since it interferes with expected behavior (a user expects the song that is clicked to play, not an random one)~~

This PR closes #418 & #495, since loop mode is already saved correctly

(There is probably a better way to implement this, but since i don't fully understand the Radio/Queue Logic this works with minimal changes)