### PR TITLE
Add Normal Search

### DIFF
--- a/app/src/main/java/io/github/zyrouge/symphony/services/Settings.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/Settings.kt
@@ -19,6 +19,7 @@ import io.github.zyrouge.symphony.ui.view.NowPlayingControlsLayout
 import io.github.zyrouge.symphony.ui.view.NowPlayingLyricsLayout
 import io.github.zyrouge.symphony.ui.view.home.ForYou
 import io.github.zyrouge.symphony.utils.ImagePreserver
+import io.github.zyrouge.symphony.utils.SearchProvider
 import io.github.zyrouge.symphony.utils.StringListUtils
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -329,6 +330,12 @@ class Settings(private val symphony: Symphony) {
     val gaplessPlayback = BooleanEntry("gapless_playback", true)
     val caseSensitiveSorting = BooleanEntry("case_sensitive_sorting", false)
     val lyricsKeepScreenAwake = BooleanEntry("lyrics_keep_screen_awake", true)
+
+    val searchProvider = EnumEntry(
+        "search_provider",
+        enumEntries<SearchProvider>(),
+        SearchProvider.Normal
+    )
 
     private fun getSharedPreferences() = symphony.applicationContext
         .getSharedPreferences("settings", Context.MODE_PRIVATE)

--- a/app/src/main/java/io/github/zyrouge/symphony/services/groove/repositories/AlbumRepository.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/groove/repositories/AlbumRepository.kt
@@ -8,6 +8,8 @@ import io.github.zyrouge.symphony.ui.helpers.createHandyImageRequest
 import io.github.zyrouge.symphony.utils.ConcurrentSet
 import io.github.zyrouge.symphony.utils.FuzzySearchOption
 import io.github.zyrouge.symphony.utils.FuzzySearcher
+import io.github.zyrouge.symphony.utils.SearchProvider
+import io.github.zyrouge.symphony.utils.Searcher
 import io.github.zyrouge.symphony.utils.concurrentSetOf
 import io.github.zyrouge.symphony.utils.joinToStringIfNotEmpty
 import io.github.zyrouge.symphony.utils.withCase
@@ -30,12 +32,22 @@ class AlbumRepository(private val symphony: Symphony) {
 
     private val cache = ConcurrentHashMap<String, Album>()
     private val songIdsCache = ConcurrentHashMap<String, ConcurrentSet<String>>()
-    private val searcher = FuzzySearcher<String>(
-        options = listOf(
-            FuzzySearchOption({ v -> get(v)?.name?.let { compareString(it) } }, 3),
-            FuzzySearchOption({ v -> get(v)?.artists?.let { compareCollection(it) } })
+    private val searcher = when (symphony.settings.searchProvider.value) {
+        SearchProvider.Fuzzy -> FuzzySearcher<String>(
+            options = listOf(
+                FuzzySearchOption({ v -> get(v)?.name?.let { compareString(it) } }, 3),
+                FuzzySearchOption({ v -> get(v)?.artists?.let { compareCollection(it) } })
+            )
         )
-    )
+
+        SearchProvider.Normal -> Searcher<String>(
+            listOf(
+                { v -> get(v)?.name ?: "" },
+                { v -> get(v)?.artists?.joinToString { it } ?: "" }
+            )
+        )
+    }
+
 
     val isUpdating get() = symphony.groove.exposer.isUpdating
     private val _all = MutableStateFlow<List<String>>(emptyList())

--- a/app/src/main/java/io/github/zyrouge/symphony/services/groove/repositories/ArtistRepository.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/groove/repositories/ArtistRepository.kt
@@ -8,6 +8,8 @@ import io.github.zyrouge.symphony.ui.helpers.createHandyImageRequest
 import io.github.zyrouge.symphony.utils.ConcurrentSet
 import io.github.zyrouge.symphony.utils.FuzzySearchOption
 import io.github.zyrouge.symphony.utils.FuzzySearcher
+import io.github.zyrouge.symphony.utils.SearchProvider
+import io.github.zyrouge.symphony.utils.Searcher
 import io.github.zyrouge.symphony.utils.concurrentSetOf
 import io.github.zyrouge.symphony.utils.withCase
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,9 +28,15 @@ class ArtistRepository(private val symphony: Symphony) {
     private val cache = ConcurrentHashMap<String, Artist>()
     private val songIdsCache = ConcurrentHashMap<String, ConcurrentSet<String>>()
     private val albumIdsCache = ConcurrentHashMap<String, ConcurrentSet<String>>()
-    private val searcher = FuzzySearcher<String>(
-        options = listOf(FuzzySearchOption({ v -> get(v)?.name?.let { compareString(it) } }))
-    )
+    private val searcher = when (symphony.settings.searchProvider.value) {
+        SearchProvider.Fuzzy -> FuzzySearcher<String>(
+            options = listOf(FuzzySearchOption({ v -> get(v)?.name?.let { compareString(it) } }))
+        )
+
+        SearchProvider.Normal -> Searcher<String>(
+            listOf { v -> get(v)?.name ?: "" }
+        )
+    }
 
     val isUpdating get() = symphony.groove.exposer.isUpdating
     private val _all = MutableStateFlow<List<String>>(emptyList())

--- a/app/src/main/java/io/github/zyrouge/symphony/services/groove/repositories/GenreRepository.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/groove/repositories/GenreRepository.kt
@@ -6,6 +6,8 @@ import io.github.zyrouge.symphony.services.groove.Song
 import io.github.zyrouge.symphony.utils.ConcurrentSet
 import io.github.zyrouge.symphony.utils.FuzzySearchOption
 import io.github.zyrouge.symphony.utils.FuzzySearcher
+import io.github.zyrouge.symphony.utils.SearchProvider
+import io.github.zyrouge.symphony.utils.Searcher
 import io.github.zyrouge.symphony.utils.concurrentSetOf
 import io.github.zyrouge.symphony.utils.withCase
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,9 +24,15 @@ class GenreRepository(private val symphony: Symphony) {
 
     private val cache = ConcurrentHashMap<String, Genre>()
     private val songIdsCache = ConcurrentHashMap<String, ConcurrentSet<String>>()
-    private val searcher = FuzzySearcher<String>(
-        options = listOf(FuzzySearchOption({ v -> get(v)?.name?.let { compareString(it) } }))
-    )
+    private val searcher = when (symphony.settings.searchProvider.value) {
+        SearchProvider.Fuzzy -> FuzzySearcher<String>(
+            options = listOf(FuzzySearchOption({ v -> get(v)?.name?.let { compareString(it) } }))
+        )
+
+        SearchProvider.Normal -> Searcher<String>(
+            listOf { v -> get(v)?.name ?: "" }
+        )
+    }
 
     val isUpdating get() = symphony.groove.exposer.isUpdating
     private val _all = MutableStateFlow<List<String>>(emptyList())

--- a/app/src/main/java/io/github/zyrouge/symphony/ui/view/settings/GrooveSettingsView.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/view/settings/GrooveSettingsView.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.filled.FindInPage
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.LibraryMusic
 import androidx.compose.material.icons.filled.RuleFolder
+import androidx.compose.material.icons.filled.SavedSearch
 import androidx.compose.material.icons.filled.SpaceBar
 import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.TextFields
@@ -61,6 +62,7 @@ import io.github.zyrouge.symphony.ui.helpers.TransitionDurations
 import io.github.zyrouge.symphony.ui.helpers.ViewContext
 import io.github.zyrouge.symphony.ui.view.SettingsViewRoute
 import io.github.zyrouge.symphony.utils.ImagePreserver
+import io.github.zyrouge.symphony.utils.SearchProvider
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
@@ -85,6 +87,7 @@ fun GrooveSettingsView(context: ViewContext, route: GrooveSettingsViewRoute) {
     val artworkQuality by context.symphony.settings.artworkQuality.flow.collectAsState()
     val caseSensitiveSorting by context.symphony.settings.caseSensitiveSorting.flow.collectAsState()
     val useMetaphony by context.symphony.settings.useMetaphony.flow.collectAsState()
+    val searchProvider by context.symphony.settings.searchProvider.flow.collectAsState()
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -315,6 +318,22 @@ fun GrooveSettingsView(context: ViewContext, route: GrooveSettingsViewRoute) {
                             }
                         }
                     )
+                    HorizontalDivider()
+                    SettingsOptionTile(
+                        icon = {
+                            Icon(Icons.Filled.SavedSearch, null)
+                        },
+                        title = {
+                            Text("Search Provider") //TODO: add i18n
+                        },
+                        value = searchProvider,
+                        values = SearchProvider.entries
+                            .associateWith { it.label(context) },
+                        onChange = { value ->
+                            context.symphony.settings.searchProvider.setValue(value)
+                        }
+                    )
+
                 }
             }
         }
@@ -326,6 +345,12 @@ fun ImagePreserver.Quality.label(context: ViewContext) = when (this) {
     ImagePreserver.Quality.Medium -> context.symphony.t.Medium
     ImagePreserver.Quality.High -> context.symphony.t.High
     ImagePreserver.Quality.Loseless -> context.symphony.t.Loseless
+}
+
+//TODO: Replace with i18n
+fun SearchProvider.label(context: ViewContext) = when (this) {
+    SearchProvider.Fuzzy -> "Fuzzy"
+    SearchProvider.Normal -> "Normal"
 }
 
 private fun refreshMediaLibrary(symphony: Symphony, clearCache: Boolean = false) {

--- a/app/src/main/java/io/github/zyrouge/symphony/utils/Fuzzy.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/utils/Fuzzy.kt
@@ -23,17 +23,17 @@ data class FuzzySearchOption<T>(
     val weight: Int = 1,
 )
 
-data class FuzzyResultEntity<T>(
+data class SearchResultEntity<T>(
     val score: Int,
     val entity: T,
 )
 
-class FuzzySearcher<T>(val options: List<FuzzySearchOption<T>>) {
-    fun search(
+class FuzzySearcher<T>(val options: List<FuzzySearchOption<T>>) : ISearchProvider<T> {
+    override fun search(
         terms: String,
         entities: List<T>,
-        maxLength: Int = -1,
-    ): List<FuzzyResultEntity<T>> {
+        maxLength: Int,
+    ): List<SearchResultEntity<T>> {
         val results = entities
             .map { compare(terms, it) }
             .sortedByDescending { it.score }
@@ -43,7 +43,7 @@ class FuzzySearcher<T>(val options: List<FuzzySearchOption<T>>) {
         }
     }
 
-    private fun compare(terms: String, entity: T): FuzzyResultEntity<T> {
+    private fun compare(terms: String, entity: T): SearchResultEntity<T> {
         var score = 0
         val comparator = FuzzySearchComparator(terms)
         options.forEach { option ->
@@ -51,7 +51,7 @@ class FuzzySearcher<T>(val options: List<FuzzySearchOption<T>>) {
                 score = max(score, it * option.weight)
             }
         }
-        return FuzzyResultEntity(score, entity)
+        return SearchResultEntity(score, entity)
     }
 }
 

--- a/app/src/main/java/io/github/zyrouge/symphony/utils/Searcher.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/utils/Searcher.kt
@@ -1,0 +1,41 @@
+package io.github.zyrouge.symphony.utils
+
+import java.util.stream.Collectors
+
+enum class SearchProvider {
+    Normal,
+    Fuzzy
+}
+
+interface ISearchProvider<T> {
+    fun search(
+        terms: String,
+        entities: List<T>,
+        maxLength: Int = -1,
+    ) : List<SearchResultEntity<T>>
+}
+
+class Searcher<T>(private var stringGetters: List<(T) -> String>) : ISearchProvider<T> {
+    override fun search(
+        terms: String,
+        entities: List<T>,
+        maxLength: Int,
+    ): List<SearchResultEntity<T>> {
+
+        val results = entities.stream()
+            .filter { match(terms, it) }
+            .map { SearchResultEntity(terms.length - it.toString().length, it ) } //smaller names benefit
+            .sorted(Comparator.comparing { it.score })
+            .collect(Collectors.toList())
+
+        return when {
+            maxLength > -1 -> results.subListNonStrict(maxLength)
+            else -> results
+        }
+    }
+
+    private fun match(terms: String, entity: T) =
+        stringGetters
+            .map { it(entity) }
+            .any { it.contains(terms, true) }
+}

--- a/app/src/main/java/io/github/zyrouge/symphony/utils/Searcher.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/utils/Searcher.kt
@@ -24,7 +24,7 @@ class Searcher<T>(private var stringGetters: List<(T) -> String>) : ISearchProvi
 
         val results = entities.stream()
             .filter { match(terms, it) }
-            .map { SearchResultEntity(terms.length - it.toString().length, it ) } //smaller names benefit
+            .map { SearchResultEntity(stringGetters[0](it).length, it ) } //smaller names benefit
             .sorted(Comparator.comparing { it.score })
             .collect(Collectors.toList())
 


### PR DESCRIPTION
Fuzzy Search sucks.

This provides a Normal String compare Search (you can pick both, but Symphony needs to be restarted for the search provider to change)

This is a draft because i18n is missing; `//TODO`s are set accordingly