### PR TITLE
Add Drag-Queue

### DIFF
--- a/app/src/main/java/io/github/zyrouge/symphony/services/radio/RadioQueue.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/radio/RadioQueue.kt
@@ -110,6 +110,38 @@ class RadioQueue(private val symphony: Symphony) {
         }
     }
 
+    //UI drag handle is before the song, so we put droppedI before onI
+    fun handleDragAndDrop(droppedI: Int, droppedSongId: String, onI: Int) {
+        if (droppedI == onI || droppedI == onI - 1) {
+            return
+        }
+        val newIndex = if (droppedI < onI) onI - 1 else onI
+        val movedCur = currentSongIndex == droppedI
+        //remove dropped
+        originalQueue.removeAt(droppedI)
+        currentQueue.removeAt(droppedI)
+        //add
+        originalQueue.add(newIndex, droppedSongId)
+        currentQueue.add(newIndex, droppedSongId)
+        if (newIndex < currentSongIndex) {
+            currentSongIndex += 1
+        }
+        if (movedCur) {
+            //TODO: this introduces a small break in playback
+            symphony.radio.play(
+                Radio.PlayOptions(
+                    index = newIndex,
+                    autostart = symphony.radio.isPlaying,
+                    startPosition = symphony.radio.currentPlaybackPosition?.played
+                )
+            )
+            currentSongIndex = newIndex
+        } else if (droppedI < currentSongIndex) {
+            currentSongIndex--
+        }
+        symphony.radio.onUpdate.dispatch(Radio.Events.Queue.Modified)
+    }
+
     fun setLoopMode(loopMode: LoopMode) {
         currentLoopMode = loopMode
     }

--- a/app/src/main/java/io/github/zyrouge/symphony/services/radio/RadioQueue.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/radio/RadioQueue.kt
@@ -120,12 +120,8 @@ class RadioQueue(private val symphony: Symphony) {
         currentQueue.removeAt(fromIndex)
         originalQueue.add(newIndex, fromSongId)
         currentQueue.add(newIndex, fromSongId)
-        if (newIndex <= currentSongIndex) { // song moved to before currently playing
-            currentSongIndex++
-        }
-        if (fromIndex < currentSongIndex) { // song moved was before currently playing
-            currentSongIndex--
-        } else if (fromIndex == currentSongIndex) { // song moved is currently playing
+        if (fromIndex == currentSongIndex) { // song moved is currently playing
+            currentSongIndex = newIndex
             //TODO: this introduces a small break in playback
             symphony.radio.play(
                 Radio.PlayOptions(
@@ -134,7 +130,15 @@ class RadioQueue(private val symphony: Symphony) {
                     startPosition = symphony.radio.currentPlaybackPosition?.played
                 )
             )
-            currentSongIndex = newIndex
+        } else { // song moved isn't currently playing
+            // moved song was before the current song
+            if (fromIndex < currentSongIndex) {
+                currentSongIndex--
+            }
+            // moved song is inserted before current song
+            if (newIndex <= currentSongIndex) {
+                currentSongIndex++
+            }
         }
         symphony.radio.onUpdate.dispatch(Radio.Events.Queue.Modified)
     }

--- a/app/src/main/java/io/github/zyrouge/symphony/services/radio/RadioQueue.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/radio/RadioQueue.kt
@@ -110,23 +110,22 @@ class RadioQueue(private val symphony: Symphony) {
         }
     }
 
-    //UI drag handle is before the song, so we put droppedI before onI
-    fun handleDragAndDrop(droppedI: Int, droppedSongId: String, onI: Int) {
-        if (droppedI == onI || droppedI == onI - 1) {
+    // UI drop area is before the song, so we put fromI before toI
+    fun handleDragAndDrop(fromIndex: Int, fromSongId: String, toIndex: Int) {
+        if (fromIndex == toIndex || fromIndex == toIndex - 1) {
             return
         }
-        val newIndex = if (droppedI < onI) onI - 1 else onI
-        val movedCur = currentSongIndex == droppedI
-        //remove dropped
-        originalQueue.removeAt(droppedI)
-        currentQueue.removeAt(droppedI)
-        //add
-        originalQueue.add(newIndex, droppedSongId)
-        currentQueue.add(newIndex, droppedSongId)
-        if (newIndex < currentSongIndex) {
-            currentSongIndex += 1
+        val newIndex = if (fromIndex < toIndex) toIndex - 1 else toIndex
+        originalQueue.removeAt(fromIndex)
+        currentQueue.removeAt(fromIndex)
+        originalQueue.add(newIndex, fromSongId)
+        currentQueue.add(newIndex, fromSongId)
+        if (newIndex <= currentSongIndex) { // song moved to before currently playing
+            currentSongIndex++
         }
-        if (movedCur) {
+        if (fromIndex < currentSongIndex) { // song moved was before currently playing
+            currentSongIndex--
+        } else if (fromIndex == currentSongIndex) { // song moved is currently playing
             //TODO: this introduces a small break in playback
             symphony.radio.play(
                 Radio.PlayOptions(
@@ -136,8 +135,6 @@ class RadioQueue(private val symphony: Symphony) {
                 )
             )
             currentSongIndex = newIndex
-        } else if (droppedI < currentSongIndex) {
-            currentSongIndex--
         }
         symphony.radio.onUpdate.dispatch(Radio.Events.Queue.Modified)
     }

--- a/app/src/main/java/io/github/zyrouge/symphony/ui/components/SongCard.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/components/SongCard.kt
@@ -3,6 +3,7 @@ package io.github.zyrouge.symphony.ui.components
 import android.content.Intent
 import android.widget.Toast
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -66,6 +67,7 @@ fun SongCard(
     thumbnailLabel: (@Composable () -> Unit)? = null,
     thumbnailLabelStyle: SongCardThumbnailLabelStyle = SongCardThumbnailLabelStyle.Default,
     trailingOptionsContent: (@Composable ColumnScope.(() -> Unit) -> Unit)? = null,
+    cardModifier: Modifier = Modifier,
     onClick: () -> Unit,
 ) {
     val queue by context.symphony.radio.observatory.queue.collectAsState()
@@ -81,9 +83,11 @@ fun SongCard(
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+        //TODO: this onClick gets overwritten by the cardModifier,
+        // if you put the cardModifier here, the dragAndDropSource click doesn't fire
         onClick = onClick
     ) {
-        Box(modifier = Modifier.padding(12.dp, 12.dp, 4.dp, 12.dp)) {
+        Box(modifier = Modifier.padding(12.dp, 12.dp, 4.dp, 12.dp).then(cardModifier)) { //TODO: move the cardModifier somewhere appropriate
             Row(verticalAlignment = Alignment.CenterVertically) {
                 leading()
                 Box {
@@ -123,7 +127,7 @@ fun SongCard(
                     }
                 }
                 Spacer(modifier = Modifier.width(16.dp))
-                Column(modifier = Modifier.weight(1f)) {
+                Column(modifier = Modifier.weight(1f).clickable { onClick.invoke()}) { //TODO: remove this onClick after moving the cardModifier above
                     Text(
                         song.title,
                         style = MaterialTheme.typography.bodyMedium.copy(

--- a/app/src/main/java/io/github/zyrouge/symphony/ui/view/Queue.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/view/Queue.kt
@@ -1,10 +1,15 @@
 package io.github.zyrouge.symphony.ui.view
 
+import android.content.ClipData
+import android.content.ClipDescription
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.draganddrop.dragAndDropSource
+import androidx.compose.foundation.draganddrop.dragAndDropTarget
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -13,11 +18,10 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ClearAll
-import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.DragIndicator
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -28,12 +32,16 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draganddrop.DragAndDropEvent
+import androidx.compose.ui.draganddrop.DragAndDropTarget
+import androidx.compose.ui.draganddrop.DragAndDropTransferData
+import androidx.compose.ui.draganddrop.mimeTypes
+import androidx.compose.ui.draganddrop.toAndroidDragEvent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import io.github.zyrouge.symphony.services.groove.Groove
@@ -43,19 +51,22 @@ import io.github.zyrouge.symphony.ui.components.SongCard
 import io.github.zyrouge.symphony.ui.components.TopAppBarMinimalTitle
 import io.github.zyrouge.symphony.ui.helpers.ViewContext
 import io.github.zyrouge.symphony.ui.view.nowPlaying.NothingPlayingBody
+import io.github.zyrouge.symphony.utils.Logger
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 
 @Serializable
 object QueueViewRoute
 
-@OptIn(ExperimentalMaterial3Api::class)
+
+const val QueueDragAndDropLabel = "symphony_song_drag_drop"
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun QueueView(context: ViewContext) {
     val coroutineScope = rememberCoroutineScope()
     val queue by context.symphony.radio.observatory.queue.collectAsState()
     val queueIndex by context.symphony.radio.observatory.queueIndex.collectAsState()
-    val selectedSongIndices = remember { mutableStateListOf<Int>() }
     val listState = rememberLazyListState(
         initialFirstVisibleItemIndex = queueIndex,
     )
@@ -89,29 +100,15 @@ fun QueueView(context: ViewContext) {
                     }
                 },
                 actions = {
-                    when {
-                        selectedSongIndices.isNotEmpty() -> IconButton(
-                            onClick = {
-                                context.symphony.radio.queue.remove(selectedSongIndices.toList())
-                                selectedSongIndices.clear()
-                            }
-                        ) {
-                            Icon(Icons.Filled.Delete, null)
-                        }
-
-                        else -> IconButton(
-                            onClick = {
-                                showSaveDialog = !showSaveDialog
-                            }
-                        ) {
-                            Icon(Icons.Default.Save, null)
-                        }
+                    IconButton(
+                        onClick = { showSaveDialog = !showSaveDialog }
+                    ) {
+                        Icon(Icons.Default.Save, null)
                     }
 
                     IconButton(
                         onClick = {
                             context.symphony.radio.stop()
-                            selectedSongIndices.clear()
                         }
                     ) {
                         Icon(Icons.Filled.ClearAll, null)
@@ -135,44 +132,135 @@ fun QueueView(context: ViewContext) {
                             contentType = { _, _ -> Groove.Kind.SONG },
                         ) { i, songId ->
                             context.symphony.groove.song.get(songId)?.let { song ->
-                                Box {
-                                    SongCard(
-                                        context,
-                                        song,
-                                        autoHighlight = false,
-                                        highlighted = i == queueIndex,
-                                        leading = {
-                                            Checkbox(
-                                                checked = selectedSongIndices.contains(i),
-                                                onCheckedChange = {
-                                                    if (selectedSongIndices.contains(i)) {
-                                                        selectedSongIndices.remove(i)
-                                                    } else {
-                                                        selectedSongIndices.add(i)
+                                var dragBackground by remember { mutableStateOf(Color.Transparent) }
+                                Box(
+                                    Modifier
+                                        .background(dragBackground)
+                                        .dragAndDropTarget(
+                                            shouldStartDragAndDrop = {
+                                                //filter out most foreign drag&drops, can be simplified
+                                                    event ->
+                                                event.run {
+                                                    if (!event.mimeTypes()
+                                                            .contains(ClipDescription.MIMETYPE_TEXT_PLAIN)
+                                                    ) {
+                                                        Logger.warn("DropTarget", "Wrong Mimetype")
+                                                        return@run false
                                                     }
-                                                },
-                                                modifier = Modifier.offset((-4).dp)
-                                            )
-                                            Spacer(modifier = Modifier.width(8.dp))
-                                        },
-                                        thumbnailLabel = {
-                                            Text((i + 1).toString())
-                                        },
-                                        onClick = {
-                                            context.symphony.radio.jumpTo(i)
-                                            coroutineScope.launch {
-                                                listState.animateScrollToItem(i)
+                                                    if (event.toAndroidDragEvent().clipDescription.label != QueueDragAndDropLabel) {
+                                                        Logger.warn(
+                                                            "DropTarget",
+                                                            "Not $QueueDragAndDropLabel Label"
+                                                        )
+                                                        return@run false
+                                                    }
+                                                    if (event.toAndroidDragEvent().localState == null) {
+                                                        Logger.warn("DropTarget", "localState null")
+                                                        return@run false
+                                                    }
+                                                    if (event.toAndroidDragEvent().localState !is List<*>) {
+                                                        Logger.warn(
+                                                            "DropTarget",
+                                                            "Wrong ClipData localState Type ${event.toAndroidDragEvent().localState}"
+                                                        )
+                                                        return@run false
+                                                    }
+                                                    if ((event.toAndroidDragEvent().localState as List<*>).size != 2) {
+                                                        Logger.warn(
+                                                            "DropTarget",
+                                                            "Wrong List size ${(event.toAndroidDragEvent().localState as List<*>).size}"
+                                                        )
+                                                        return@run false
+                                                    }
+                                                    return@run true
+                                                }
+                                            },
+                                            target = remember {
+                                                object : DragAndDropTarget {
+                                                    override fun onEntered(event: DragAndDropEvent) {
+                                                        dragBackground =
+                                                            Color.DarkGray.copy(alpha = 0.35f)
+                                                    }
+
+                                                    override fun onExited(event: DragAndDropEvent) {
+                                                        dragBackground = Color.Transparent
+                                                    }
+
+                                                    override fun onDrop(event: DragAndDropEvent): Boolean {
+                                                        val list =
+                                                            event.toAndroidDragEvent().localState as List<*>
+                                                        val droppedI: Int =
+                                                            list[0].toString().toInt()
+                                                        val droppedSongId: String =
+                                                            list[1].toString()
+                                                        if (droppedI == i) {
+                                                            return true
+                                                        }
+                                                        //always put after the dropped song
+                                                        val newIndex =
+                                                            if (droppedI < i) i else i + 1
+                                                        //TODO: make something else when queueIndex == droppedI
+                                                        // otherwise we swap the current playing song which isn't intended
+                                                        context.symphony.radio.queue.remove(droppedI)
+                                                        context.symphony.radio.queue.add(
+                                                            droppedSongId,
+                                                            index = newIndex
+                                                        )
+                                                        return true
+                                                    }
+                                                }
                                             }
-                                        },
-                                    )
-                                    if (i < queueIndex) {
-                                        Box(
-                                            modifier = Modifier
-                                                .matchParentSize()
-                                                .background(
-                                                    MaterialTheme.colorScheme.background.copy(alpha = 0.3f)
-                                                )
                                         )
+                                ) {
+                                    Box {
+                                        SongCard(
+                                            context,
+                                            song,
+                                            autoHighlight = false,
+                                            highlighted = i == queueIndex,
+                                            leading = {
+                                                Icon(Icons.Filled.DragIndicator, null)
+                                                Spacer(modifier = Modifier.width(8.dp))
+                                            },
+                                            thumbnailLabel = {
+                                                Text((i + 1).toString())
+                                            },
+                                            cardModifier = Modifier.dragAndDropSource {
+                                                detectTapGestures(
+                                                    onLongPress = {
+                                                        startTransfer(
+                                                            DragAndDropTransferData(
+                                                                ClipData.newPlainText(
+                                                                    QueueDragAndDropLabel,
+                                                                    ""
+                                                                ),
+                                                                localState = listOf(
+                                                                    i.toString(),
+                                                                    songId
+                                                                )
+                                                            )
+                                                        )
+                                                    }
+                                                )
+                                            },
+                                            onClick = {
+                                                context.symphony.radio.jumpTo(i)
+                                                coroutineScope.launch {
+                                                    listState.animateScrollToItem(i)
+                                                }
+                                            },
+                                        )
+                                        if (i < queueIndex) {
+                                            Box(
+                                                modifier = Modifier
+                                                    .matchParentSize()
+                                                    .background(
+                                                        MaterialTheme.colorScheme.background.copy(
+                                                            alpha = 0.3f
+                                                        )
+                                                    )
+                                            )
+                                        }
                                     }
                                 }
                             }

--- a/app/src/main/java/io/github/zyrouge/symphony/ui/view/Queue.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/view/Queue.kt
@@ -1,24 +1,15 @@
 package io.github.zyrouge.symphony.ui.view
 
-import android.content.ClipData
-import android.content.ClipDescription
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.draganddrop.dragAndDropSource
-import androidx.compose.foundation.draganddrop.dragAndDropTarget
-import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ClearAll
-import androidx.compose.material.icons.filled.DragIndicator
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -37,11 +28,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draganddrop.DragAndDropEvent
-import androidx.compose.ui.draganddrop.DragAndDropTarget
-import androidx.compose.ui.draganddrop.DragAndDropTransferData
-import androidx.compose.ui.draganddrop.mimeTypes
-import androidx.compose.ui.draganddrop.toAndroidDragEvent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import io.github.zyrouge.symphony.services.groove.Groove
@@ -51,17 +37,13 @@ import io.github.zyrouge.symphony.ui.components.SongCard
 import io.github.zyrouge.symphony.ui.components.TopAppBarMinimalTitle
 import io.github.zyrouge.symphony.ui.helpers.ViewContext
 import io.github.zyrouge.symphony.ui.view.nowPlaying.NothingPlayingBody
-import io.github.zyrouge.symphony.utils.Logger
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 
 @Serializable
 object QueueViewRoute
 
-
-const val QueueDragAndDropLabel = "symphony_song_drag_drop"
-
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun QueueView(context: ViewContext) {
     val coroutineScope = rememberCoroutineScope()
@@ -132,136 +114,36 @@ fun QueueView(context: ViewContext) {
                             contentType = { _, _ -> Groove.Kind.SONG },
                         ) { i, songId ->
                             context.symphony.groove.song.get(songId)?.let { song ->
-                                var dragBackground by remember { mutableStateOf(Color.Transparent) }
-                                Box(
-                                    Modifier
-                                        .background(dragBackground)
-                                        .dragAndDropTarget(
-                                            shouldStartDragAndDrop = {
-                                                //filter out most foreign drag&drops, can be simplified
-                                                    event ->
-                                                event.run {
-                                                    if (!event.mimeTypes()
-                                                            .contains(ClipDescription.MIMETYPE_TEXT_PLAIN)
-                                                    ) {
-                                                        Logger.warn("DropTarget", "Wrong Mimetype")
-                                                        return@run false
-                                                    }
-                                                    if (event.toAndroidDragEvent().clipDescription.label != QueueDragAndDropLabel) {
-                                                        Logger.warn(
-                                                            "DropTarget",
-                                                            "Not $QueueDragAndDropLabel Label"
-                                                        )
-                                                        return@run false
-                                                    }
-                                                    if (event.toAndroidDragEvent().localState == null) {
-                                                        Logger.warn("DropTarget", "localState null")
-                                                        return@run false
-                                                    }
-                                                    if (event.toAndroidDragEvent().localState !is List<*>) {
-                                                        Logger.warn(
-                                                            "DropTarget",
-                                                            "Wrong ClipData localState Type ${event.toAndroidDragEvent().localState}"
-                                                        )
-                                                        return@run false
-                                                    }
-                                                    if ((event.toAndroidDragEvent().localState as List<*>).size != 2) {
-                                                        Logger.warn(
-                                                            "DropTarget",
-                                                            "Wrong List size ${(event.toAndroidDragEvent().localState as List<*>).size}"
-                                                        )
-                                                        return@run false
-                                                    }
-                                                    return@run true
-                                                }
-                                            },
-                                            target = remember {
-                                                object : DragAndDropTarget {
-                                                    override fun onEntered(event: DragAndDropEvent) {
-                                                        dragBackground =
-                                                            Color.DarkGray.copy(alpha = 0.35f)
-                                                    }
-
-                                                    override fun onExited(event: DragAndDropEvent) {
-                                                        dragBackground = Color.Transparent
-                                                    }
-
-                                                    override fun onDrop(event: DragAndDropEvent): Boolean {
-                                                        val list =
-                                                            event.toAndroidDragEvent().localState as List<*>
-                                                        val droppedI: Int =
-                                                            list[0].toString().toInt()
-                                                        val droppedSongId: String =
-                                                            list[1].toString()
-                                                        if (droppedI == i) {
-                                                            return true
-                                                        }
-                                                        //always put after the dropped song
-                                                        val newIndex =
-                                                            if (droppedI < i) i else i + 1
-                                                        //TODO: make something else when queueIndex == droppedI
-                                                        // otherwise we swap the current playing song which isn't intended
-                                                        context.symphony.radio.queue.remove(droppedI)
-                                                        context.symphony.radio.queue.add(
-                                                            droppedSongId,
-                                                            index = newIndex
-                                                        )
-                                                        return true
-                                                    }
-                                                }
+                                Box {
+                                    SongCard(
+                                        context,
+                                        song,
+                                        autoHighlight = false,
+                                        highlighted = i == queueIndex,
+                                        thumbnailLabel = {
+                                            Text((i + 1).toString())
+                                        },
+                                        modifier = if (i < queueIndex) Modifier.background(
+                                            MaterialTheme.colorScheme.background.copy(
+                                                alpha = 0.3f
+                                            )
+                                        ) else Modifier,
+                                        onClick = {
+                                            context.symphony.radio.jumpTo(i)
+                                            coroutineScope.launch {
+                                                listState.animateScrollToItem(i)
                                             }
-                                        )
-                                ) {
-                                    Box {
-                                        SongCard(
-                                            context,
-                                            song,
-                                            autoHighlight = false,
-                                            highlighted = i == queueIndex,
-                                            leading = {
-                                                Icon(Icons.Filled.DragIndicator, null)
-                                                Spacer(modifier = Modifier.width(8.dp))
-                                            },
-                                            thumbnailLabel = {
-                                                Text((i + 1).toString())
-                                            },
-                                            cardModifier = Modifier.dragAndDropSource {
-                                                detectTapGestures(
-                                                    onLongPress = {
-                                                        startTransfer(
-                                                            DragAndDropTransferData(
-                                                                ClipData.newPlainText(
-                                                                    QueueDragAndDropLabel,
-                                                                    ""
-                                                                ),
-                                                                localState = listOf(
-                                                                    i.toString(),
-                                                                    songId
-                                                                )
-                                                            )
-                                                        )
-                                                    }
-                                                )
-                                            },
-                                            onClick = {
-                                                context.symphony.radio.jumpTo(i)
-                                                coroutineScope.launch {
-                                                    listState.animateScrollToItem(i)
-                                                }
-                                            },
-                                        )
-                                        if (i < queueIndex) {
-                                            Box(
-                                                modifier = Modifier
-                                                    .matchParentSize()
-                                                    .background(
-                                                        MaterialTheme.colorScheme.background.copy(
-                                                            alpha = 0.3f
-                                                        )
-                                                    )
+                                        },
+                                        dragAndDropEnabled = true,
+                                        dragAndDropPos = i,
+                                        dragAndDropAction = { droppedI: Int, droppedSongId: String ->
+                                            context.symphony.radio.queue.handleDragAndDrop(
+                                                droppedI,
+                                                droppedSongId,
+                                                i
                                             )
                                         }
-                                    }
+                                    )
                                 }
                             }
                         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 activity-compose = "1.9.3"
 coil = "2.7.0"
-compose = "1.7.5"
+compose = "1.9.0"
 compose-material = "1.7.5"
 compose-material3 = "1.3.1"
 compose-navigation = "2.8.4"


### PR DESCRIPTION
This Draft Adds Drag&Drop Queue Control, closing #37 & #595 

Current Issues/Limitations:
- Logging still included, overcomplicated way of checking if the event is valid (since the drag&drop is Android-global)
- No autoscroll when hitting lower/upper 20% of the screen (you need a second finger to scroll inside the queue)
- The drop field is small since i didn't want to introduce z layers or alter the design of the list
- The song queue entries (in the queue) are thinner than before (same reason as above) -> smaller clickable area and uglier onClick  
- the drag&drop is only implemented for the playing queue -> can easily be implemented everywhere else, i just didn't bother
- the drag doesn't have a clear preview (the preview is only the drag icon, not the whole song entry)
- moving the currently playing song calls ``symphony.radio.play``, pausing the music for ~0.5s

Fixed Problems:
- ~~The drag&drop source detectTapGestures interferes with the SongCard Card onClick -> temporarily added Card onClick to Song title/author (could be fixed by using detectTapGestures for both, or limiting the detectTapGestures into its own space with a SongCard shadow)~~ -> moved the drag area out of the onClick
- ~~uses ExperimentalFoundationApi~~ -> dragAndDrop features aren't Experimental since compose-foundation 1.8
- ~~Drag&dropping the currently playing song will change the currently playing song~~ -> fixed in second commit
- ~~Unclear where the drop will land~~ -> moved the drop zones between the queue entries