### PR TITLE
Initial Song Deletion

### DIFF
--- a/app/src/main/java/io/github/zyrouge/symphony/services/groove/Groove.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/groove/Groove.kt
@@ -1,5 +1,8 @@
 package io.github.zyrouge.symphony.services.groove
 
+import android.net.Uri
+import android.provider.DocumentsContract
+import android.widget.Toast
 import io.github.zyrouge.symphony.Symphony
 import io.github.zyrouge.symphony.services.groove.repositories.AlbumArtistRepository
 import io.github.zyrouge.symphony.services.groove.repositories.AlbumRepository
@@ -7,6 +10,8 @@ import io.github.zyrouge.symphony.services.groove.repositories.ArtistRepository
 import io.github.zyrouge.symphony.services.groove.repositories.GenreRepository
 import io.github.zyrouge.symphony.services.groove.repositories.PlaylistRepository
 import io.github.zyrouge.symphony.services.groove.repositories.SongRepository
+import io.github.zyrouge.symphony.utils.ActivityUtils
+import io.github.zyrouge.symphony.utils.Logger
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -86,5 +91,45 @@ class Groove(private val symphony: Symphony) : Symphony.Hooks {
             fetch()
             readyDeferred.complete(true)
         }
+    }
+
+    fun delete(songToDelete: Song) {
+        coroutineScope.launch {
+            if (delete(songToDelete.uri)) {
+                //TODO: if currently playing song gets deleted
+                coroutineScope.launch {
+                    awaitAll(
+                        async { symphony.radio.queue.removeAll(songToDelete.id) },
+                        async { song.delete(songToDelete) },
+                        async { album.delete(songToDelete) },
+                        async { artist.delete(songToDelete) },
+                        async { albumArtist.delete(songToDelete) },
+                        async { genre.delete(songToDelete) },
+                        async { playlist.deleteSong(songToDelete) },
+                    )
+                }.join()
+            }
+        }
+    }
+
+    internal fun delete(uri: Uri): Boolean {
+        val cR = symphony.applicationContext.contentResolver
+        //TODO: check if this makes sense, this technically should never get called
+        if (cR.persistedUriPermissions.none {
+                val parent = DocumentsContract.getTreeDocumentId(it.uri)
+                DocumentsContract.getDocumentId(uri).startsWith("${parent}/")
+            }) {
+            Logger.warn("Deleter", "Don't have Permissions, asking")
+            ActivityUtils.makePersistableReadableUri(symphony.applicationContext, uri)
+        }
+        try {
+            DocumentsContract.deleteDocument(cR, uri)
+        } catch (e: SecurityException) {
+            Logger.error("Deleter", "Couldn't delete: $e")
+            Toast.makeText(symphony.applicationContext, "Failed to delete Song", Toast.LENGTH_SHORT)
+                .show()
+            return false
+        }
+        return true
     }
 }

--- a/app/src/main/java/io/github/zyrouge/symphony/services/groove/repositories/AlbumArtistRepository.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/groove/repositories/AlbumArtistRepository.kt
@@ -71,6 +71,40 @@ class AlbumArtistRepository(private val symphony: Symphony) {
         }
     }
 
+    fun delete(song: Song) {
+        song.albumArtists.forEach { albumArtistId ->
+            var single = false
+            if (songIdsCache.contains(albumArtistId)) {
+                when (songIdsCache.size) {
+                    1 -> {
+                        single = true
+                        songIdsCache.remove(albumArtistId)
+                    }
+
+                    else -> songIdsCache[albumArtistId]?.remove(song.id)
+                }
+            }
+
+            //TODO: remove album from albumArtist if it has no more songs
+            val nNumberOfAlbums = albumIdsCache[albumArtistId]?.size ?: 0
+
+            if (cache.contains(albumArtistId)) {
+                if (single) {
+                    cache.remove(albumArtistId)
+                    _all.update {
+                        it - albumArtistId
+                    }
+                    emitCount()
+                } else {
+                    cache[albumArtistId]?.apply {
+                        numberOfAlbums = nNumberOfAlbums
+                        numberOfTracks--
+                    }
+                }
+            }
+        }
+    }
+
     fun reset() {
         cache.clear()
         _all.update {

--- a/app/src/main/java/io/github/zyrouge/symphony/services/groove/repositories/AlbumRepository.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/groove/repositories/AlbumRepository.kt
@@ -83,6 +83,37 @@ class AlbumRepository(private val symphony: Symphony) {
         }
     }
 
+    internal fun delete(song: Song) {
+        val albumId = getIdFromSong(song) ?: return
+        var single = false
+        if (songIdsCache.contains(albumId)) {
+            when (songIdsCache.size) {
+                1 -> {
+                    single = true
+                    songIdsCache.remove(albumId)
+                }
+
+                else -> songIdsCache[albumId]?.remove(song.id)
+            }
+        }
+        if (cache.contains(albumId)) {
+            if (single) {
+                cache.remove(albumId)
+                _all.update {
+                    it + albumId
+                }
+                emitCount()
+            } else {
+                cache[albumId]?.apply {
+                    //TODO: remove artists if needed
+                    //TODO: change album year if needed
+                    numberOfTracks--
+                    duration -= song.duration.milliseconds
+                }
+            }
+        }
+    }
+
     fun reset() {
         cache.clear()
         songIdsCache.clear()

--- a/app/src/main/java/io/github/zyrouge/symphony/services/groove/repositories/ArtistRepository.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/groove/repositories/ArtistRepository.kt
@@ -71,6 +71,40 @@ class ArtistRepository(private val symphony: Symphony) {
         }
     }
 
+    fun delete(song: Song) {
+        song.artists.forEach { artistId ->
+            var single = false
+            if (songIdsCache.contains(artistId)) {
+                when (songIdsCache.size) {
+                    1 -> {
+                        single = true
+                        songIdsCache.remove(artistId)
+                    }
+
+                    else -> songIdsCache[artistId]?.remove(song.id)
+                }
+            }
+
+            //TODO: remove album from artist if it has no more songs
+            val nNumberOfAlbums = albumIdsCache[artistId]?.size ?: 0
+
+            if (cache.contains(artistId)) {
+                if (single) {
+                    cache.remove(artistId)
+                    _all.update {
+                        it - artistId
+                    }
+                    emitCount()
+                } else {
+                    cache[artistId]?.apply {
+                        numberOfAlbums = nNumberOfAlbums
+                        numberOfTracks--
+                    }
+                }
+            }
+        }
+    }
+
     fun reset() {
         cache.clear()
         _all.update {

--- a/app/src/main/java/io/github/zyrouge/symphony/services/groove/repositories/GenreRepository.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/groove/repositories/GenreRepository.kt
@@ -58,6 +58,35 @@ class GenreRepository(private val symphony: Symphony) {
         }
     }
 
+    fun delete(song: Song) {
+        song.genres.forEach { genreId ->
+            var single = false
+            if (songIdsCache.contains(genreId)) {
+                when (songIdsCache[genreId]?.size) {
+                    1 -> {
+                        single = true
+                        songIdsCache.remove(genreId)
+                    }
+
+                    else -> songIdsCache[genreId]?.remove(song.id)
+                }
+            }
+            if (cache.contains(genreId)) {
+                if (single) {
+                    cache.remove(genreId)
+                    _all.update {
+                        it - genreId
+                    }
+                    emitCount()
+                } else {
+                    cache[genreId]?.apply {
+                        numberOfTracks--
+                    }
+                }
+            }
+        }
+    }
+
     fun reset() {
         cache.clear()
         songIdsCache.clear()

--- a/app/src/main/java/io/github/zyrouge/symphony/services/groove/repositories/SongRepository.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/groove/repositories/SongRepository.kt
@@ -72,6 +72,21 @@ class SongRepository(private val symphony: Symphony) {
         emitCount()
     }
 
+    fun delete(song: Song) {
+        if (cache.contains(song.id)) {
+            cache.remove(song.id)
+        }
+        if (pathCache.contains(song.path)) {
+            pathCache.remove(song.path)
+        }
+        explorer.removeChildFile(SimplePath(song.path))
+        emitIds()
+        _all.update {
+            it - song.id
+        }
+        emitCount()
+    }
+
     fun reset() {
         cache.clear()
         pathCache.clear()

--- a/app/src/main/java/io/github/zyrouge/symphony/services/radio/RadioQueue.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/radio/RadioQueue.kt
@@ -110,6 +110,17 @@ class RadioQueue(private val symphony: Symphony) {
         }
     }
 
+    fun removeAll(id: String) {
+        //TODO: check if logic makes sense
+        val currentSongRemoved = currentSongId == id
+        currentQueue.removeAll { it == id }
+        originalQueue.removeAll { it == id }
+        symphony.radio.onUpdate.dispatch(Radio.Events.Queue.Modified)
+        if (currentSongRemoved) {
+            symphony.radio.play(Radio.PlayOptions(index = currentSongIndex))
+        }
+    }
+
     fun setLoopMode(loopMode: LoopMode) {
         currentLoopMode = loopMode
     }

--- a/app/src/main/java/io/github/zyrouge/symphony/ui/components/DeleteSongDialog.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/components/DeleteSongDialog.kt
@@ -1,0 +1,41 @@
+package io.github.zyrouge.symphony.ui.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import io.github.zyrouge.symphony.services.groove.Song
+import io.github.zyrouge.symphony.ui.helpers.ViewContext
+
+@Composable
+fun DeleteSongDialog(context: ViewContext, song: Song, onDismissRequest: () -> Unit) {
+    InformationDialog(
+        //TODO: change title from details to something normal
+        context,
+        content = {
+            Text("Do you want to delete the Song\n ${song.title}?") //TODO: i18n
+            Row(
+                Modifier.fillMaxWidth(),
+            ) {
+                Button(
+                    onClick = {
+                        context.symphony.groove.delete(song)
+                        onDismissRequest()
+                    }
+                ) {
+                    Text("Yes") //TODO: i18n
+                }
+                Spacer(Modifier.weight(1f))
+                Button(
+                    onClick = onDismissRequest
+                ) {
+                    Text("No") //TODO: i18n
+                }
+            }
+        },
+        onDismissRequest = onDismissRequest,
+    )
+}

--- a/app/src/main/java/io/github/zyrouge/symphony/ui/components/SongCard.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/components/SongCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material.icons.automirrored.filled.PlaylistPlay
 import androidx.compose.material.icons.filled.Album
+import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.MoreVert
@@ -200,6 +201,7 @@ fun SongDropdownMenu(
 ) {
     var showInfoDialog by remember { mutableStateOf(false) }
     var showAddToPlaylistDialog by remember { mutableStateOf(false) }
+    var showDeleteDialog by remember { mutableStateOf(false) }
 
     DropdownMenu(
         expanded = expanded,
@@ -344,6 +346,18 @@ fun SongDropdownMenu(
                 showInfoDialog = true
             }
         )
+        DropdownMenuItem(
+            leadingIcon = {
+                Icon(Icons.Filled.DeleteForever, null)
+            },
+            text = {
+                Text("Delete Song", color = Color.Red) //TODO: i18n
+            },
+            onClick = {
+                onDismissRequest()
+                showDeleteDialog = true
+            }
+        )
         trailingContent?.invoke(this, onDismissRequest)
     }
 
@@ -363,6 +377,16 @@ fun SongDropdownMenu(
             songIds = listOf(song.id),
             onDismissRequest = {
                 showAddToPlaylistDialog = false
+            }
+        )
+    }
+
+    if (showDeleteDialog) {
+        DeleteSongDialog(
+            context,
+            song = song,
+            onDismissRequest = {
+                showDeleteDialog = false
             }
         )
     }

--- a/app/src/main/java/io/github/zyrouge/symphony/utils/ActivityUtils.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/utils/ActivityUtils.kt
@@ -23,7 +23,7 @@ object ActivityUtils {
     fun makePersistableReadableUri(context: Context, uri: Uri) {
         context.contentResolver.takePersistableUriPermission(
             uri,
-            Intent.FLAG_GRANT_READ_URI_PERMISSION
+            Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
         )
     }
 

--- a/app/src/main/java/io/github/zyrouge/symphony/utils/SimpleFileSystem.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/utils/SimpleFileSystem.kt
@@ -46,6 +46,13 @@ sealed class SimpleFileSystem(val parent: Folder?, val name: String) {
             return child
         }
 
+        private fun removeChildFile(name: String) {
+            if (!children.containsKey(name)) {
+                throw Exception("Child '$name' doesn't exist")
+            }
+            children.remove(name)
+        }
+
         fun addChildFile(path: SimplePath): File {
             val parts = path.parts.toMutableList()
             var parent = this
@@ -59,6 +66,21 @@ sealed class SimpleFileSystem(val parent: Folder?, val name: String) {
                 }
             }
             return parent.addChildFile(parts[0])
+        }
+
+        fun removeChildFile(path: SimplePath) {
+            val parts = path.parts.toMutableList()
+            var parent = this
+            while (parts.size > 1) {
+                val x = parts.removeAt(0)
+                val found = parent.children[x]
+                parent = when (found) {
+                    is Folder -> found
+                    null -> parent.addChildFolder(x)
+                    else -> throw Exception("Child '$x' is not a folder")
+                }
+            }
+            parent.removeChildFile(parts[0])
         }
     }
 }


### PR DESCRIPTION
This PR adds the Ability to delete Songs (from Disk permanently), but you will need to re-add your current Source Folders for writing Permissions.

Limitations/Missing/TODOs:
- You currently can only delete one song at a time, but album/artist/etc deletion should be easy to implement
- The deletion function has a write perm check that isn't tested and might create an Exception (might be candidate to delete)
- I'm not 100% certain whether the `RadioQueue.removeAll()` logic is fine as-is -> should be re-checked
- Some Repositories don't get updates that they would need (see `TODO`s in code, i personally don't mind whether the artist album count is correct after deletion, some will) -> potential for NPE's
- Logging still in Code
- i18n missing
- The `DeleteSongDialog` has "Details" as title, as the Structure is copied from the song information dialog