### PR TITLE
Replace "Now Playing" with Album Title if Album Title exists

### DIFF
--- a/app/src/main/java/io/github/zyrouge/symphony/ui/view/nowPlaying/AppBar.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/view/nowPlaying/AppBar.kt
@@ -19,14 +19,15 @@ import androidx.compose.ui.unit.dp
 import io.github.zyrouge.symphony.ui.components.IconButtonPlaceholder
 import io.github.zyrouge.symphony.ui.components.TopAppBarMinimalTitle
 import io.github.zyrouge.symphony.ui.helpers.ViewContext
+import io.github.zyrouge.symphony.ui.view.NowPlayingData
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun NowPlayingAppBar(context: ViewContext) {
+fun NowPlayingAppBar(context: ViewContext, data: NowPlayingData?) {
     CenterAlignedTopAppBar(
         title = {
             TopAppBarMinimalTitle {
-                Text(context.symphony.t.NowPlaying)
+                Text(if (data == null || data.song.album == null) context.symphony.t.NowPlaying else data.song.album.toString())
             }
         },
         colors = TopAppBarDefaults.centerAlignedTopAppBarColors(

--- a/app/src/main/java/io/github/zyrouge/symphony/ui/view/nowPlaying/Body.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/view/nowPlaying/Body.kt
@@ -43,7 +43,7 @@ fun NowPlayingBody(context: ViewContext, data: NowPlayingData) {
                 modifier = Modifier.fillMaxSize(),
                 topBar = {
                     if (orientation.isPortrait) {
-                        NowPlayingAppBar(context)
+                        NowPlayingAppBar(context, data)
                     }
                 },
                 content = { contentPadding ->

--- a/app/src/main/java/io/github/zyrouge/symphony/ui/view/nowPlaying/NothingPlaying.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/ui/view/nowPlaying/NothingPlaying.kt
@@ -18,7 +18,7 @@ fun NothingPlaying(context: ViewContext) {
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         topBar = {
-            NowPlayingAppBar(context)
+            NowPlayingAppBar(context, null)
         },
         content = { contentPadding ->
             Box(


### PR DESCRIPTION
Always felt that the "Now Playing" is just a waste of space.

Closes issue #708.

- This does show "Now Playing" if the song doesn't have an Album Title linked to it.
- This should show "Now Playing" if there is nothing playing. I wasn't able to test this, but I'm sure enough it works.