### PR TITLE
Resume playback after an interruption

### DIFF
--- a/app/src/main/java/io/github/zyrouge/symphony/services/radio/Radio.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/radio/Radio.kt
@@ -212,7 +212,6 @@ class Radio(private val symphony: Symphony) : Symphony.Hooks {
                 forceFade = forceFade,
             ) { _ ->
                 it.pause()
-                focus.abandonFocus()
                 onFinish()
                 onUpdate.dispatch(Events.Player.Paused)
             }
@@ -230,6 +229,7 @@ class Radio(private val symphony: Symphony) : Symphony.Hooks {
         stopCurrentSong()
         queue.reset()
         clearSleepTimer()
+        focus.abandonFocus()
         persistedSpeed = RadioPlayer.DEFAULT_SPEED
         persistedPitch = RadioPlayer.DEFAULT_PITCH
         if (ended) onUpdate.dispatch(Events.Player.Ended)


### PR DESCRIPTION
Currently, when receiving a phone call while playback is in progress:
- playback is paused
- audio focus is abandoned

When the phone call ends, as audio focus was abandoned, playback cannot be automatically resumed.

In order to change this behavior, I simply moved the call to `focus.abandonFocus()` from `pause()` to `stop()`.
