### PR TITLE
fix: improve metaphony date parsing

### DIFF
--- a/app/src/main/java/io/github/zyrouge/symphony/services/groove/Song.kt
+++ b/app/src/main/java/io/github/zyrouge/symphony/services/groove/Song.kt
@@ -167,7 +167,7 @@ data class Song(
                 discNumber = metadata.discNumber,
                 discTotal = metadata.discTotal,
                 date = metadata.date,
-                year = metadata.date?.year,
+                year = metadata.year,
                 duration = metadata.lengthInSeconds?.let { it * 1000L } ?: 0,
                 bitrate = metadata.bitrate?.let { it * 1000L },
                 samplingRate = metadata.sampleRate?.toLong(),

--- a/metaphony/src/main/java/me/zyrouge/symphony/metaphony/AudioMetadata.kt
+++ b/metaphony/src/main/java/me/zyrouge/symphony/metaphony/AudioMetadata.kt
@@ -1,7 +1,6 @@
 package me.zyrouge.symphony.metaphony
 
 import java.time.LocalDate
-import java.time.Year
 
 data class AudioMetadata(
     val title: String?,

--- a/metaphony/src/main/java/me/zyrouge/symphony/metaphony/AudioMetadata.kt
+++ b/metaphony/src/main/java/me/zyrouge/symphony/metaphony/AudioMetadata.kt
@@ -1,6 +1,7 @@
 package me.zyrouge.symphony.metaphony
 
 import java.time.LocalDate
+import java.time.Year
 
 data class AudioMetadata(
     val title: String?,
@@ -14,6 +15,7 @@ data class AudioMetadata(
     val trackNumber: Int?,
     val trackTotal: Int?,
     val date: LocalDate?,
+    val year: Int?,
     val lyrics: String?,
     val encoding: String?,
     val bitrate: Int?,

--- a/metaphony/src/main/java/me/zyrouge/symphony/metaphony/AudioMetadataParser.kt
+++ b/metaphony/src/main/java/me/zyrouge/symphony/metaphony/AudioMetadataParser.kt
@@ -2,8 +2,9 @@ package me.zyrouge.symphony.metaphony
 
 import me.zyrouge.symphony.metaphony.AudioMetadata.Picture
 import java.time.LocalDate
+import java.time.Year
+import java.time.YearMonth
 import java.time.format.DateTimeFormatter
-import kotlin.String
 
 class AudioMetadataParser private constructor() {
     // Tags keys can be found at https://taglib.org/api/p_propertymapping.html
@@ -47,7 +48,8 @@ class AudioMetadataParser private constructor() {
             discTotal = discTotal,
             trackNumber = trackNumber,
             trackTotal = trackTotal ?: tags["TRACKTOTAL"]?.firstOrNull()?.toIntOrNull(),
-            date = tags["DATE"]?.firstOrNull()?.let { parseDate(it) },
+            date = tags["DATE"]?.firstOrNull()?.let { parseDate(it) } ?: tags["YEAR"]?.firstOrNull()
+                ?.let { parseDate(it) },
             lyrics = tags["LYRICS"]?.firstOrNull(),
             encoding = tags["ENCODING"]?.firstOrNull(),
             bitrate = audioProperties["BITRATE"],
@@ -80,16 +82,15 @@ class AudioMetadataParser private constructor() {
             return split[0].toIntOrNull() to split[1].toIntOrNull()
         }
 
-        val DATE_YEAR = DateTimeFormatter.ofPattern("yyyy")
-        val DATE_YEAR_MONTH = DateTimeFormatter.ofPattern("yyyy")
-        val DATE_YEAR_MONTH_DATE = DateTimeFormatter.ISO_LOCAL_DATE
+        val DATE_NOW: LocalDate = LocalDate.now()
+        val DATE_YEAR_MONTH_DATE: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE
 
         private fun parseDate(text: String): LocalDate? {
             runCatching {
-                return LocalDate.parse(text, DATE_YEAR)
+                return Year.parse(text).atMonth(DATE_NOW.month).atDay(DATE_NOW.dayOfMonth)
             }
             runCatching {
-                return LocalDate.parse(text, DATE_YEAR_MONTH)
+                return YearMonth.parse(text).atDay(DATE_NOW.dayOfMonth)
             }
             runCatching {
                 return LocalDate.parse(text, DATE_YEAR_MONTH_DATE)

--- a/metaphony/src/main/java/me/zyrouge/symphony/metaphony/AudioMetadataParser.kt
+++ b/metaphony/src/main/java/me/zyrouge/symphony/metaphony/AudioMetadataParser.kt
@@ -48,8 +48,9 @@ class AudioMetadataParser private constructor() {
             discTotal = discTotal,
             trackNumber = trackNumber,
             trackTotal = trackTotal ?: tags["TRACKTOTAL"]?.firstOrNull()?.toIntOrNull(),
-            date = tags["DATE"]?.firstOrNull()?.let { parseDate(it) } ?: tags["YEAR"]?.firstOrNull()
-                ?.let { parseDate(it) },
+            date = tags["DATE"]?.firstOrNull()?.let { parseDate(it) },
+            year = tags["YEAR"]?.firstOrNull()?.let { parseYear(it) } ?: tags["DATE"]?.firstOrNull()
+                ?.let { parseYear(it) },
             lyrics = tags["LYRICS"]?.firstOrNull(),
             encoding = tags["ENCODING"]?.firstOrNull(),
             bitrate = audioProperties["BITRATE"],
@@ -82,18 +83,24 @@ class AudioMetadataParser private constructor() {
             return split[0].toIntOrNull() to split[1].toIntOrNull()
         }
 
-        val DATE_NOW: LocalDate = LocalDate.now()
         val DATE_YEAR_MONTH_DATE: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE
 
         private fun parseDate(text: String): LocalDate? {
             runCatching {
-                return Year.parse(text).atMonth(DATE_NOW.month).atDay(DATE_NOW.dayOfMonth)
-            }
-            runCatching {
-                return YearMonth.parse(text).atDay(DATE_NOW.dayOfMonth)
-            }
-            runCatching {
                 return LocalDate.parse(text, DATE_YEAR_MONTH_DATE)
+            }
+            return null
+        }
+
+        private fun parseYear(text: String): Int? {
+            runCatching {
+                return Year.parse(text).value
+            }
+            runCatching {
+                return YearMonth.parse(text).year
+            }
+            runCatching {
+                return LocalDate.parse(text, DATE_YEAR_MONTH_DATE).year
             }
             return null
         }


### PR DESCRIPTION
- Using `LocalDate` to parse a partial date (i.e. `yyyy` or `yyyy-MM`) will always fail as they are not considered valid dates. Instead, use `Year` and `YearMonth` to parse partial date tags.
- In the case of a partial date, the year value will be preserved but not the date value
  - Example below:

| | |
|---|---|
| <img width="460" height="449" alt="image" src="https://github.com/user-attachments/assets/5ce63f25-2f7c-4ba5-b84c-d433bb6d3a6f" /> | <img width="460" height="449" alt="image" src="https://github.com/user-attachments/assets/dfbaa716-460c-4ad9-8951-a5b6c9781247" /> |

- Also check for `"YEAR"` tag before checking `"DATE"` tag.
- Fixes #656 